### PR TITLE
Add missing dashes in pre-commit run

### DIFF
--- a/pages/02.blog/how-to-create-a-python-package-in-2022/item.md
+++ b/pages/02.blog/how-to-create-a-python-package-in-2022/item.md
@@ -196,7 +196,7 @@ After this, we install the hooks and then we run them once, just for good measur
 
 ```bash
 pre-commit install
-pre-commit run all-files
+pre-commit run --all-files
 ```
 
 ! Make sure your Poetry virtual environment is active!


### PR DESCRIPTION
The currently provided pre-commit run command is:
`pre-commit run all-files`
Which results in:
```No hook with id `all-files` in stage `commit` ```

This PR suggests a change in the pre-commit run command by adding `--`:
```pre-commit run --all-files```
which results in the pre-commits running as expected:
```
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check toml...............................................................Passed
check yaml...........................................(no files to check)Skipped
fix end of files.........................................................Passed
mixed line ending........................................................Passed
black....................................................................Failed
- hook id: black
- files were modified by this hook
```