### PR TITLE
Update footer links and icons

### DIFF
--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -73,12 +73,12 @@ THEME_MY_QUARK:
 
 FOOTER:
   ICON_TITLES:
-    YOUTUBE: Subscribe to the YouTube channel
-    INSIDER: Join the mathspp insider community
-    DROPS: Check out Python drops
-    BLUESKY: Follow @mathsppblog on BlueSky
-    TWITTER: Follow @mathsppblog on X/Twitter
-    EMAIL: Email me
+    YOUTUBE: "Subscribe to the YouTube channel"
+    INSIDER: "Subscribe to the weekly mathspp insider 🐍🚀 newsletter"
+    DROPS: "Get a daily drop of Python knowledge 🐍💧"
+    BLUESKY: "Follow @mathspp.com on BlueSky"
+    TWITTER: "Follow @mathsppblog on X/Twitter"
+    EMAIL: "Email me"
 
 TAG_DESCRIPTIONS:
   algorithms: "Implementation and use cases for computer science algorithms"
@@ -177,3 +177,4 @@ TAG_DESCRIPTIONS:
   visualisation: "Articles that feature visualisations of algorithms, simulations, and others"
   vscode: "The usage of Visual Studio Code"
   web development: "Web development"
+

--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -73,15 +73,12 @@ THEME_MY_QUARK:
 
 FOOTER:
   ICON_TITLES:
-    SPONSOR: "Sponsor this project"
-    TWITCH: "Follow me on Twitch for programming streams"
-    YOUTUBE: "Subscribe to the YouTube channel"
-    GITHUB: Star the blog content and contribute on GitHub
-    FACEBOOK: Like mathspp on Facebook
-    TWITTER: Follow @mathsppblog on Twitter
-    INSTAGRAM: Follow @mathsppblog on Instagram
-    NEWSLETTER: Subscribe to the newsletter
-    EMAIL: Email me at rodrigo(at)mathspp(dot)com
+    YOUTUBE: Subscribe to the YouTube channel
+    INSIDER: Join the mathspp insider community
+    DROPS: Check out Python drops
+    BLUESKY: Follow @mathsppblog on BlueSky
+    TWITTER: Follow @mathsppblog on X/Twitter
+    EMAIL: Email me
 
 TAG_DESCRIPTIONS:
   algorithms: "Implementation and use cases for computer science algorithms"

--- a/themes/myquark/templates/partials/footer.html.twig
+++ b/themes/myquark/templates/partials/footer.html.twig
@@ -38,22 +38,22 @@
     <div>
         <!-- Footer with Font Awesome icons. -->
         <div class="social-icon-container">
-            <a target="_blank" href="https://twitter.com/mathsppblog/" title="{{ 'FOOTER.ICON_TITLES.TWITTER'|t }}"><i class="social-icon fab fa-twitter" alt="Twitter"></i></a>
+            <a target="_blank" href="https://youtube.com/@mathsppblog" title="{{ 'FOOTER.ICON_TITLES.YOUTUBE'|t }}"><i class="social-icon fab fa-youtube" alt="YouTube"></i></a>
         </div>
         <div class="social-icon-container">
-            <a target="_blank" href="https://github.com/sponsors/rodrigogiraoserrao" title="{{ 'FOOTER.ICON_TITLES.SPONSOR'|t }}"><i class="social-icon fas fa-heart" alt="Heart"></i></a>
+            <a target="_blank" href="https://mathspp.com/insider" title="{{ 'FOOTER.ICON_TITLES.INSIDER'|t }}"><i class="social-icon fas fa-rocket" alt="mathspp insider"></i></a>
         </div>
         <div class="social-icon-container">
-            <a target="_blank" href="https://mathspp.com/youtube" title="{{ 'FOOTER.ICON_TITLES.YOUTUBE'|t }}"><i class="social-icon fab fa-youtube" alt="YouTube"></i></a>
+            <a target="_blank" href="https://mathspp.com/drops" title="{{ 'FOOTER.ICON_TITLES.DROPS'|t }}"><i class="social-icon fas fa-tint" alt="Python drops"></i></a>
         </div>
         <div class="social-icon-container">
-            <a target="_blank" href="https://github.com/mathspp/mathspp" title="{{ 'FOOTER.ICON_TITLES.GITHUB'|t }}"><i class="social-icon fab fa-github" alt="GitHub"></i></a>
+            <a target="_blank" href="https://bsky.app/profile/mathspp.com" title="{{ 'FOOTER.ICON_TITLES.BLUESKY'|t }}"><i class="social-icon fas fa-cloud" alt="BlueSky"></i></a>
         </div>
         <div class="social-icon-container">
-            <a target="_blank" href="https://mathspp.com/subscribe" title="{{ 'FOOTER.ICON_TITLES.NEWSLETTER'|t }}"><i class="social-icon fas fa-envelope-open-text" alt="Newsletter"></i></a>
+            <a target="_blank" href="https://x.com/mathsppblog" title="{{ 'FOOTER.ICON_TITLES.TWITTER'|t }}"><i class="social-icon fab fa-twitter" alt="X/Twitter"></i></a>
         </div>
         <div class="social-icon-container">
-            <a target="_blank" href="mailto:rodrigo@mathspp.com?subject=Getting in touch." title="{{ 'FOOTER.ICON_TITLES.EMAIL'|t }}"><i class="social-icon fas fa-at" alt="Email"></i></a>
+            <a target="_blank" href="https://mathspp.com/contact-me" title="{{ 'FOOTER.ICON_TITLES.EMAIL'|t }}"><i class="social-icon fas fa-at" alt="Email"></i></a>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- refresh footer with Font Awesome links to YouTube, mathspp insider, Python drops, BlueSky, X/Twitter and email
- add English translations for new footer link titles

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c8120cf4c483259462b908309bc9e7