### PR TITLE
Limit snippet card description to first paragraph

### DIFF
--- a/themes/myquark/templates/partials/python-vault/snippet-card.html.twig
+++ b/themes/myquark/templates/partials/python-vault/snippet-card.html.twig
@@ -53,8 +53,14 @@
     {% endif %}
 
     {% if snippet.content %}
+        {% set content_split = snippet.content|split('</p>', 2) %}
+        {% set first_paragraph = content_split[0] %}
+        {% if '</p>' in snippet.content %}
+            {% set first_paragraph = first_paragraph ~ '</p>' %}
+        {% endif %}
+
         <div class="python-vault__description">
-            {{ snippet.content|raw }}
+            {{ first_paragraph|raw }}
         </div>
     {% endif %}
 </article>

--- a/themes/myquark/templates/python-vault-snippet.html.twig
+++ b/themes/myquark/templates/python-vault-snippet.html.twig
@@ -6,9 +6,21 @@
 {% endblock %}
 
 {% block content %}
+    {% set content_split = page.content|split('</p>', 2) %}
+    {% set additional_content = '' %}
+    {% if content_split|length > 1 %}
+        {% set additional_content = content_split[1] %}
+    {% endif %}
+
     <section class="python-vault python-vault--single">
         {% include 'partials/python-vault/snippet-card.html.twig' with { snippet: page, is_list: false } %}
     </section>
+
+    {% if additional_content %}
+        <div class="python-vault__additional-content">
+            {{ additional_content|raw }}
+        </div>
+    {% endif %}
 {% endblock %}
 
 {% block bottom %}


### PR DESCRIPTION
## Summary
- show only the opening paragraph in the Python Vault snippet card description
- render any remaining snippet content after the card on the single snippet page

## Testing
- not run (templates only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4c28799883258aa1e3ef4abf40e2)