### PR TITLE
Add Add new snippet CTA and snippet attribution to Python Vault

### DIFF
--- a/themes/myquark/css/python-vault.css
+++ b/themes/myquark/css/python-vault.css
@@ -16,6 +16,42 @@
     color: var(--tx);
 }
 
+.python-vault__cta {
+    margin-top: 2rem;
+    text-align: center;
+}
+
+.python-vault__cta--hero {
+    margin-top: 2.5rem;
+}
+
+.python-vault__cta--list-bottom,
+.python-vault__cta--page-bottom {
+    margin-top: 3rem;
+}
+
+.python-vault__add-snippet-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    border-radius: 999px;
+    border: medium;
+    background-color: var(--accent);
+    color: var(--bg);
+    font-weight: 700;
+    text-decoration: none;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.python-vault__add-snippet-button:hover,
+.python-vault__add-snippet-button:focus {
+    background-color: var(--accent-2);
+    transform: translateY(-1px);
+    outline: currentColor;
+}
+
 .python-vault__controls {
     margin-bottom: 1.5rem;
 }
@@ -99,6 +135,16 @@
 .python-vault__snippet-title {
     margin: 0px;
 
+}
+
+.python-vault__snippet-suggester {
+    display: inline-block;
+    margin-right: 0.5rem;
+    font-size: 0.65rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--tx);
+    opacity: 0.85;
 }
 
 .python-vault__snippet-title a {

--- a/themes/myquark/templates/partials/python-vault/add-snippet-button.html.twig
+++ b/themes/myquark/templates/partials/python-vault/add-snippet-button.html.twig
@@ -1,0 +1,4 @@
+{% set url = url|default('https://github.com/mathspp/mathspp/issues/new/choose') %}
+<a class="python-vault__add-snippet-button" href="{{ url }}" target="_blank" rel="noopener noreferrer">
+    Add new snippet
+</a>

--- a/themes/myquark/templates/partials/python-vault/snippet-card.html.twig
+++ b/themes/myquark/templates/partials/python-vault/snippet-card.html.twig
@@ -11,10 +11,14 @@
 {% set code_block_id = 'python-vault-code-' ~ snippet.slug %}
 {% set snippet_tags = snippet.taxonomy['snippet-tags']|default([]) %}
 {% set search_source = (snippet.title ~ ' ' ~ snippet_tags|join(' ') ~ ' ' ~ snippet.content|striptags)|lower|replace({'\n': ' '}) %}
+{% set suggested_by = attribute(snippet.header, 'suggested-by')|default(null) %}
 
 <article class="python-vault__snippet" data-python-vault-card data-search-text="{{ search_source|e('html_attr') }}">
     <header class="python-vault__snippet-header">
         <{{ heading_tag }} class="python-vault__snippet-title">
+            {% if suggested_by %}
+                <span class="python-vault__snippet-suggester">suggested by {{ suggested_by }}</span>
+            {% endif %}
             {% if is_list %}
                 <a href="{{ snippet.url }}">{{ snippet.title }}</a>
             {% else %}

--- a/themes/myquark/templates/python-vault-snippet.html.twig
+++ b/themes/myquark/templates/python-vault-snippet.html.twig
@@ -21,6 +21,10 @@
             {{ additional_content|raw }}
         </div>
     {% endif %}
+
+    <div class="python-vault__cta python-vault__cta--page-bottom">
+        {% include 'partials/python-vault/add-snippet-button.html.twig' %}
+    </div>
 {% endblock %}
 
 {% block bottom %}

--- a/themes/myquark/templates/python-vault.html.twig
+++ b/themes/myquark/templates/python-vault.html.twig
@@ -1,4 +1,5 @@
 {% extends 'partials/base.html.twig' %}
+{% set python_vault_add_snippet_url = 'https://github.com/mathspp/mathspp/issues/new/choose' %}
 {% set hero_image_url = header_var('hero_image_url', [page])|defined('') %}
 {% set python_vault_hero_image = page.media.images[page.header.hero_image] ?: page.media.images|first %}
 {% set has_python_vault_hero = hero_image_url != '' or python_vault_hero_image is not empty %}
@@ -7,6 +8,9 @@
     {% if page.content %}
         {{ page.content|raw }}
     {% endif %}
+    <div class="python-vault__cta python-vault__cta--hero">
+        {% include 'partials/python-vault/add-snippet-button.html.twig' with { url: python_vault_add_snippet_url } %}
+    </div>
 {% endset %}
 
 {% block hero %}
@@ -40,6 +44,9 @@
                         {{ page.content|raw }}
                     </div>
                 {% endif %}
+                <div class="python-vault__cta">
+                    {% include 'partials/python-vault/add-snippet-button.html.twig' with { url: python_vault_add_snippet_url } %}
+                </div>
             </header>
         {% endif %}
 
@@ -67,6 +74,10 @@
             {% for snippet in snippets %}
                 {% include 'partials/python-vault/snippet-card.html.twig' with { snippet: snippet, is_list: true } %}
             {% endfor %}
+        </div>
+
+        <div class="python-vault__cta python-vault__cta--list-bottom">
+            {% include 'partials/python-vault/add-snippet-button.html.twig' with { url: python_vault_add_snippet_url } %}
         </div>
     </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a reusable partial that renders an "Add new snippet" button linking to the GitHub issue template
- surface the button in the Python Vault hero, list footer, and snippet pages while styling the new call-to-action
- show snippet suggester attribution inline with each snippet title when a `suggested-by` header is present

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120dc5b7bc8325aa70e16ab173d6a3)