### PR TITLE
Add card-based Insider archive template with compact issue cards

### DIFF
--- a/pages/insider/archive/blog.md
+++ b/pages/insider/archive/blog.md
@@ -2,6 +2,7 @@
 process:
     twig: true
 cache_enable: false
+template: insider-archive
 
 body_classes: "header-dark header-transparent"
 content:

--- a/themes/myquark/templates/insider-archive.html.twig
+++ b/themes/myquark/templates/insider-archive.html.twig
@@ -1,0 +1,37 @@
+{% extends 'partials/base.html.twig' %}
+{% set hero_image_url = header_var("hero_image_url", [page])|defined("") %}
+{% set blog_image = page.media.images[page.header.hero_image] ?: page.media.images|first %}
+{% set collection = page.collection() %}
+{% set blog = page.find(header_var('blog_url')|defined(theme_var('blog-page'))) %}
+{% set show_breadcrumbs = header_var('show_breadcrumbs', [page, blog])|defined(true) %}
+{% set show_pagination = header_var('show_pagination', [page, blog])|defined(true) %}
+
+{% block hero %}
+    {% include 'partials/hero.html.twig' with {id: 'insider-archive-hero', content: page.content, hero_image_url: hero_image_url, hero_image: blog_image} %}
+{% endblock %}
+
+{% block body %}
+    <section id="body-wrapper" class="section blog-listing insider-archive-listing">
+        <section class="container {{ grid_size }}">
+
+        {% if show_breadcrumbs and config.plugins.breadcrumbs.enabled %}
+            {% include 'partials/breadcrumbs.html.twig' %}
+        {% endif %}
+
+        <div class="columns">
+            {% for child in collection %}
+                <div class="column col-4 col-md-6 col-sm-12">
+                    {% include 'partials/insider-archive-card.html.twig' with {page: child} %}
+                </div>
+            {% endfor %}
+        </div>
+
+        {% if show_pagination and config.plugins.pagination.enabled and collection.params.pagination %}
+            <div id="listing-footer">
+                {% include 'partials/pagination.html.twig' with {base_url: page.url, pagination: collection.params.pagination} %}
+            </div>
+        {% endif %}
+
+        </section>
+    </section>
+{% endblock %}

--- a/themes/myquark/templates/partials/insider-archive-card.html.twig
+++ b/themes/myquark/templates/partials/insider-archive-card.html.twig
@@ -1,0 +1,16 @@
+<div class="card">
+    {% set image = page.media.images|first %}
+    {% if image %}
+        <div class="card-image">
+            <a href="{{ page.url }}">{{ image.cropZoom(800, 400).html|raw }}</a>
+        </div>
+    {% endif %}
+    <div class="card-header">
+        <div class="card-subtitle text-gray">
+            {% include 'partials/blog/date.html.twig' %}
+        </div>
+        <div class="card-title">
+            <h6><a href="{{ page.url }}">{{ page.title }}</a></h6>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
### Motivation
- Provide an archive page for the Insider newsletter that keeps the hero and subscription form but displays past issues in a compact, card-based layout instead of the default blog listing.  
- Show each issue's image when available and link the title to the issue without rendering any post preview text.

### Description
- Added a dedicated Twig page template `themes/myquark/templates/insider-archive.html.twig` that preserves the hero (and embedded subscription form) and renders newsletter issues in a responsive grid with pagination.  
- Added a partial `themes/myquark/templates/partials/insider-archive-card.html.twig` that renders a small card per issue, including the issue image only when present and the title linking to the issue, with no content preview.  
- Updated `pages/insider/archive/blog.md` to use the `insider-archive` template while keeping the original hero copy and form.  

### Testing
- Verified the file diffs and template wiring via inspection and `git diff` to confirm the new template and partial are referenced by the page. (succeeded)  
- Printed and reviewed the modified files with `nl`/`sed` to confirm header and template changes (succeeded).  
- Captured a rendered screenshot of `/insider/archive` using a Playwright script to confirm the page renders the hero and the responsive card grid (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a3bdc9b7c8325a25635e119b21f78)